### PR TITLE
Suggestion: Hide Active Buff Duration (Show Only Cooldowns)

### DIFF
--- a/JobBars/Cooldowns/CooldownConfig.cs
+++ b/JobBars/Cooldowns/CooldownConfig.cs
@@ -24,7 +24,7 @@ namespace JobBars.Cooldowns {
             Name = name;
             Icon = props.Icon;
             Triggers = props.Triggers;
-            Duration = props.Duration;
+            Duration = JobBars.Config.CooldownsHideActiveBuffDuration ? 0 : props.Duration;
             CD = props.CD;
             Enabled = JobBars.Config.CooldownEnabled.Get(Name);
             Order = JobBars.Config.CooldownOrder.Get(Name);

--- a/JobBars/Cooldowns/Manager/CooldownManager.UI.cs
+++ b/JobBars/Cooldowns/Manager/CooldownManager.UI.cs
@@ -46,6 +46,10 @@ namespace JobBars.Cooldowns.Manager {
                 JobBars.Config.Save();
             }
 
+            if (ImGui.Checkbox("Hide Active Buff Duration (Show Only Cooldowns)" + _ID, ref JobBars.Config.CooldownsHideActiveBuffDuration)) {
+                JobBars.Config.Save();
+            }
+
             ImGui.Unindent();
         }
 

--- a/JobBars/Data/Configuration.cs
+++ b/JobBars/Data/Configuration.cs
@@ -91,6 +91,8 @@ namespace JobBars.Data {
         public bool CooldownsEnabled = true;
         public bool CooldownsHideOutOfCombat = false;
         public bool CooldownsShowBorderWhenActive = true;
+        public bool CooldownsHideActiveBuffDuration = false;
+
 
         public bool CooldownsLeftAligned = false;
 


### PR DESCRIPTION
Hi, I don't want to see the time the buff is valid on the cooldown list.
So I thought it would be nice if there was an option to enable only the cooldown, what do you think?