### PR TITLE
add PCT hammer gauge

### DIFF
--- a/JobBars/Data/Ids.Buffs.cs
+++ b/JobBars/Data/Ids.Buffs.cs
@@ -179,6 +179,7 @@ namespace JobBars.Data {
         Hyperphantasia = 3688,
         SubtractivePaletee = 3674,
         StarryMuse = 3685,
+        HammerTime = 3680,
 
         // BLU =========
         BluBleed = 1714,

--- a/JobBars/Jobs/PCT.cs
+++ b/JobBars/Jobs/PCT.cs
@@ -7,6 +7,7 @@ using JobBars.Gauges;
 using JobBars.Gauges.Stacks;
 using JobBars.Helper;
 using JobBars.Icons;
+using JobBars.Gauges.Timer;
 
 namespace JobBars.Jobs {
     public static class PCT {
@@ -24,6 +25,13 @@ namespace JobBars.Jobs {
                     new Item(BuffIds.SubtractivePaletee)
                 ],
                 Color = ColorConstants.BlueGreen
+            }),
+            new GaugeTimerConfig(UiHelper.Localize(BuffIds.HammerTime), GaugeVisualType.Bar, new GaugeSubTimerProps {
+                MaxDuration = 30,
+                Color = ColorConstants.Orange,
+                Triggers = [
+                    new Item(BuffIds.HammerTime)
+                ],
             }),
         ];
 


### PR DESCRIPTION
PCT's hammer combo won't be interrupted by other skills, so I use a timer gauge instead of stacks gauge.
