### PR TITLE
Update container sizing for Buff and Cooldown roots

### DIFF
--- a/JobBars/Nodes/Buff/BuffRoot.cs
+++ b/JobBars/Nodes/Buff/BuffRoot.cs
@@ -33,6 +33,13 @@ namespace JobBars.Nodes.Buff {
                 Buffs[idx].Position = new( xMod * ( BuffNode.WIDTH + 9 ) * position_x, yMod * ( BuffNode.HEIGHT + 7 ) * position_y );
             }
             foreach( var buff in Buffs ) buff.Update();
+
+            // Update container size to fit content
+            var columns = BUFFS_HORIZONTAL == 0 ? 1 : BUFFS_HORIZONTAL;
+            var rows = BUFFS_HORIZONTAL == 0 ? MAX_BUFFS : ( MAX_BUFFS + columns - 1 ) / columns;
+            var width = columns * ( BuffNode.WIDTH + 9 );
+            var height = rows * ( BuffNode.HEIGHT + 7 );
+            Size = new( width, height );
         }
     }
 }

--- a/JobBars/Nodes/Cooldown/CooldownNode.cs
+++ b/JobBars/Nodes/Cooldown/CooldownNode.cs
@@ -24,6 +24,7 @@ namespace JobBars.Nodes.Cooldown {
                 Size = new( WIDTH, HEIGHT ),
                 NodeFlags = NodeFlags.Visible,
                 ImageNodeFlags = ImageNodeFlags.AutoFit,
+                WrapMode = WrapMode.Stretch,
                 TextureSize = new( 44, 46 ),
                 IconId = 405
             };

--- a/JobBars/Nodes/Cooldown/CooldownRoot.cs
+++ b/JobBars/Nodes/Cooldown/CooldownRoot.cs
@@ -26,6 +26,11 @@ namespace JobBars.Nodes.Cooldown {
 
         public void Update() {
             for( var i = 0; i < 8; i++ ) Rows[i].Position = new( 0, JobBars.Configuration.CooldownsSpacing * i );
+
+            // Update container size to fit content
+            var width = ( 5 + CooldownNode.WIDTH ) * CooldownRow.MAX_ITEMS;
+            var height = JobBars.Configuration.CooldownsSpacing * 8;
+            Size = new( width, height );
         }
 
         public void SetCooldownRowVisible( int idx, bool visible ) => Rows[idx].IsVisible = visible;


### PR DESCRIPTION
BuffRoot and CooldownRoot now dynamically update their Size properties to fit their child content. CooldownNode also sets WrapMode to Stretch